### PR TITLE
Fix middleware configuration in settings.py

### DIFF
--- a/hr_training_site/settings.py
+++ b/hr_training_site/settings.py
@@ -44,7 +44,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'allauth.account.middleware.AccountMiddleware',  # Added middleware
+    'allauth.middleware.AccountMiddleware',  # Added middleware
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]


### PR DESCRIPTION
Update middleware configuration in `hr_training_site/settings.py`.

* Remove `allauth.account.middleware.AccountMiddleware` from the `MIDDLEWARE` list.
* Add `allauth.middleware.AccountMiddleware` to the `MIDDLEWARE` list.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/VPJPDB/JPDBEmployeePortal/pull/4?shareId=a4abfc79-5f65-43d0-90c4-c1a07c69f230).