### PR TITLE
Fix middleware configuration

### DIFF
--- a/hr_training_site/settings.py
+++ b/hr_training_site/settings.py
@@ -44,7 +44,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'allauth.middleware.AccountMiddleware',  # Added middleware
+    'allauth.account.middleware.AccountMiddleware',  # Added middleware
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]


### PR DESCRIPTION
Update middleware configuration in `hr_training_site/settings.py`.

* Change `'allauth.middleware.AccountMiddleware'` to `'allauth.account.middleware.AccountMiddleware'` in the `MIDDLEWARE` list.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/VPJPDB/JPDBEmployeePortal/pull/5?shareId=57d087e4-3733-4708-ac54-5fbb10b3505b).