### PR TITLE
Make files smaller

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tzdata==2024.2
 Django==5.1.3
 django-environ==0.4.5  # if you've used django-environ
 gunicorn==20.1.0
+psycopg2==2.9.3


### PR DESCRIPTION
Add psycopg2 dependency to requirements.txt

* Add `psycopg2==2.9.3` to the requirements.txt file to include the PostgreSQL adapter for Python.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/VPJPDB/JPDBEmployeePortal/pull/7?shareId=0ddd77d1-c68e-4452-b52d-4bc2f844c243).